### PR TITLE
A better timeout implementation for Safe#eval

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    jruby_sandbox (0.1.1-java)
+    jruby_sandbox (0.1.2-java)
       fakefs
 
 GEM

--- a/ext/java/sandbox/SandboxFull.java
+++ b/ext/java/sandbox/SandboxFull.java
@@ -17,11 +17,13 @@ import org.jruby.runtime.Block;
 import org.jruby.runtime.builtin.IRubyObject;
 import org.jruby.common.IRubyWarnings;
 import org.jruby.exceptions.RaiseException;
+import org.jruby.runtime.DynamicScope;
 
 
 @JRubyClass(name="Sandbox::Full")
 public class SandboxFull extends RubyObject {
   private Ruby wrapped;
+  private DynamicScope currentScope;
 
   public SandboxFull(Ruby runtime, RubyClass type) {
     super(runtime, type);
@@ -45,6 +47,8 @@ public class SandboxFull extends RubyObject {
 
     RubyClass cBoxedClass = wrapped.defineClass("BoxedClass", wrapped.getObject(), wrapped.getObject().getAllocator());
     cBoxedClass.defineAnnotatedMethods(BoxedClass.class);
+    
+    currentScope = wrapped.getCurrentContext().getCurrentScope();
 
     return this;
   }
@@ -52,7 +56,7 @@ public class SandboxFull extends RubyObject {
   @JRubyMethod(required=1)
   public IRubyObject eval(IRubyObject str) {
     try {
-      IRubyObject result = wrapped.evalScriptlet(str.asJavaString(), wrapped.getCurrentContext().getCurrentScope());
+      IRubyObject result = wrapped.evalScriptlet(str.asJavaString(), currentScope);
       return unbox(result);
     } catch (RaiseException e) {
       String msg = e.getException().callMethod(wrapped.getCurrentContext(), "message").asJavaString();


### PR DESCRIPTION
- now Safe#eval takes an options hash that accepts the :timeout option for seconds
- this will wrap a super call in a custom timeout code (using the Timeout library does not work) using Threads and Thread#kill!
- this code was 'borrowed' from javasand
- I had to move the getCurrentScope() call to the initialization of the sandbox so the scope would persist between eval calls
