### PR TITLE
Use the official fakefs with Ruby 1.9 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "http://rubygems.org"
 gemspec
 
 # this fork has some recent work done for 1.9, like File.foreach
-gem 'fakefs', :git => 'git://github.com/nanothief/fakefs.git', :require => 'fakefs/safe'
+gem 'fakefs'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,14 @@
-GIT
-  remote: git://github.com/nanothief/fakefs.git
-  revision: cb63ff262e1ab9dffdda6d20a1b9c90434e97d58
-  specs:
-    fakefs (0.3.2)
-
 PATH
   remote: .
   specs:
-    jruby_sandbox (0.1.1-java)
+    jruby_sandbox (0.1.2-java)
       fakefs
 
 GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.1.2)
+    fakefs (0.4.2)
     rake (0.9.2)
     rake-compiler (0.7.9)
       rake
@@ -31,7 +26,7 @@ PLATFORMS
   java
 
 DEPENDENCIES
-  fakefs!
+  fakefs
   jruby_sandbox!
   rake
   rake-compiler


### PR DESCRIPTION
The official fakefs has been updated with 1.9 support, and the nanothief fork no longer exists.

This solves the build problem mentioned in #8.
